### PR TITLE
kern: perf: 增加report的参数

### DIFF
--- a/SOURCE/script/test.sh
+++ b/SOURCE/script/test.sh
@@ -111,7 +111,11 @@ perf() {
 
 	eval "$DIAG_CMD perf --deactivate --activate='style=0 idle=1 bvt=1'"
 	sleep 1
-	eval "$DIAG_CMD perf --report --deactivate"
+	eval "$DIAG_CMD perf --report"
+	sleep 1
+	eval "$DIAG_CMD perf --report='out=perf.out'"
+	eval "$DIAG_CMD perf --report='in=perf.out'"
+	eval "$DIAG_CMD perf --deactivate"
 }
 
 kprobe() {


### PR DESCRIPTION
增加in/out参数，这样允许将数据临时输出到文件而不解析。